### PR TITLE
feat(menu): add truncate to group label

### DIFF
--- a/Sidebar/Group/index.tsx
+++ b/Sidebar/Group/index.tsx
@@ -23,10 +23,14 @@ const SidebarGroup = forwardRef<HTMLLIElement, SidebarGroupProps>(
 
     return (
       <SidebarGroupContext.Provider value={contextValue}>
-        <li id={id} className={cn(className, 'uizz-layout-block uizz-layout-select-none')} ref={ref}>
+        <li
+          id={id}
+          className={cn(className, 'uizz-layout-block uizz-layout-select-none uizz-layout-overflow-hidden')}
+          ref={ref}
+        >
           {!!label && (
             <div
-              className='uizz-layout-relative uizz-layout-box-border uizz-layout-grid uizz-layout-min-h-[2.2rem] uizz-layout-cursor-pointer uizz-layout-grid-cols-[1.625rem_1fr] uizz-layout-items-center uizz-layout-gap-2 uizz-layout-rounded-br-[50px] uizz-layout-rounded-tr-[50px] uizz-layout-px-4 uizz-layout-py-2 uizz-layout-leading-[1.15] uizz-layout-outline-none uizz-layout-transition-all hover:uizz-layout-bg-content-title/[0.03] active:uizz-layout-bg-content-title/[0.03] dark:hover:uizz-layout-bg-content-title/[0.08] dark:active:uizz-layout-bg-content-title/[0.03] '
+              className='uizz-layout-relative uizz-layout-box-border uizz-layout-grid uizz-layout-min-h-[2.2rem] uizz-layout-cursor-pointer uizz-layout-grid-cols-[1.625rem_1fr] uizz-layout-items-center uizz-layout-gap-2 uizz-layout-rounded-br-[50px] uizz-layout-rounded-tr-[50px] uizz-layout-px-4 uizz-layout-py-2 uizz-layout-leading-[1.15] uizz-layout-outline-none uizz-layout-transition-all hover:uizz-layout-bg-content-title/[0.03] active:uizz-layout-bg-content-title/[0.03] dark:hover:uizz-layout-bg-content-title/[0.08] dark:active:uizz-layout-bg-content-title/[0.03]'
               onClick={toogleExpanded}
               tabIndex={tabIndex ?? 1}
             >
@@ -40,7 +44,7 @@ const SidebarGroup = forwardRef<HTMLLIElement, SidebarGroupProps>(
                 )}
               />
 
-              <div className='uizz-layout-col-[2] uizz-layout-min-w-0'>
+              <div className='uizz-layout-col-[2] uizz-layout-min-w-0 uizz-layout-truncate'>
                 <span className='uizz-layout-overflow-hidden uizz-layout-text-ellipsis uizz-layout-whitespace-nowrap uizz-layout-break-all uizz-layout-text-sm uizz-layout-uppercase uizz-layout-tracking-[0.03em] uizz-layout-text-content-title/[0.65]'>
                   {label}
                 </span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
## What?
add truncate to menu group label

## Why?
<img width="273" alt="Screenshot 2024-08-22 at 16 43 23" src="https://github.com/user-attachments/assets/0b17cb76-f07b-4f5b-8545-bbe1f0fc6119">


## How?
add overflow hidden and tailwind truncate class

## Testing?
locally

## Screenshots (optional)
<img width="255" alt="Screenshot 2024-08-22 at 16 44 06" src="https://github.com/user-attachments/assets/1337c0ef-3b66-465a-87fa-fd5d0a73e19f">

## Anything Else?
`=]`
