### PR TITLE
fix(persistMode): add persistMode verification to get mode from cookie

### DIFF
--- a/hooks/useMode.tsx
+++ b/hooks/useMode.tsx
@@ -34,7 +34,15 @@ export default function useMode({ mode, acceptModeBySearchParam, persistMode, on
       return searchParamsMode;
     }
 
-    const storageMode = cookies.get('eduzz-theme') as PossibleModes | undefined;
+    const getThemeCookie = () => {
+      if (!persistMode) {
+        return undefined;
+      }
+
+      return cookies.get('eduzz-theme') as PossibleModes | undefined;
+    };
+
+    const storageMode = getThemeCookie();
 
     if (!storageMode) {
       return mode || 'light';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
## What?
add persistMode verification to get mode from cookie

## Why?
was applying the saved theme on pages without defining the persistMode

## How?
add persistMode verification to get mode from cookie

## Testing?
locally changing the persist mode

## Anything Else?
`=]`