### PR TITLE
Hyperflow JWT to pass data and keep chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,17 +177,18 @@ function MyComponent() {
 
 ### Topbar.UnitySupportChat props
 
-| prop  | tipo                    | obrigatório | padrão | descrição                                         |
-|-------|-------------------------|-------------|--------|---------------------------------------------------|
-| token | `() => Promise<string>` | `false`     | -      | Token gerado pelo servidor para uso do LiveHelper |
+| prop  | tipo     | obrigatório | padrão | descrição                                         |
+|-------|----------|-------------|--------|---------------------------------------------------|
+| token | `string` | `false`     | -      | Token gerado pelo servidor para uso do LiveHelper |
 
 ### Topbar.HyperflowSupportChat props
 
-| prop            | tipo              | obrigatório | padrão | descrição                                            |
-|-----------------|-------------------|-------------|--------|------------------------------------------------------|
-| hyperflowConfig | `HyperflowConfig` | `true`      | -      | Tokens dos canais do Hyperflow                       |
-| flowId          | `string`          | `true`      | -      | Id do flow do Hyperflow                              |
-| currentUser     | `CurrentUser`     | `true`      | -      | Dados do usuário que serão enviados para o Hyperflow |
+| prop            | tipo                    | obrigatório | padrão | descrição                                            |
+|-----------------|-------------------------|-------------|--------|------------------------------------------------------|
+| accountsJwt     | `() => Promise<string>` | `true`      | -      | JWT gerado a partir do accounts                      |
+| hyperflowConfig | `HyperflowConfig`       | `true`      | -      | Tokens dos canais do Hyperflow                       |
+| currentUser     | `CurrentUser`           | `true`      | -      | Dados do usuário que serão enviados para o Hyperflow |
+| hyperflowJwt    | `string`                | `true`      | -      | JWT gerado a partir do secret da Hyperflow           |
 
 ```ts
 export type CurrentUser = {

--- a/Topbar/HyperflowSupportChat/index.tsx
+++ b/Topbar/HyperflowSupportChat/index.tsx
@@ -2,12 +2,18 @@ import HyperflowSupportChat from './chat';
 import { TopbarHyperflowSupportChatProps } from './types';
 
 const TopbarHyperflowSupportChat = ({
-  getJwtPromise,
+  accountsJwt,
   currentUser,
-  hyperflowConfig
+  hyperflowConfig,
+  hyperflowJwt
 }: TopbarHyperflowSupportChatProps) => {
   return (
-    <HyperflowSupportChat getJwtPromise={getJwtPromise} currentUser={currentUser} hyperflowConfig={hyperflowConfig} />
+    <HyperflowSupportChat
+      accountsJwt={accountsJwt}
+      currentUser={currentUser}
+      hyperflowConfig={hyperflowConfig}
+      hyperflowJwt={hyperflowJwt}
+    />
   );
 };
 

--- a/Topbar/HyperflowSupportChat/types.ts
+++ b/Topbar/HyperflowSupportChat/types.ts
@@ -25,9 +25,10 @@ export type HyperflowConfig = {
 };
 
 export type TopbarHyperflowSupportChatProps = {
-  getJwtPromise: () => Promise<string>;
+  accountsJwt: () => Promise<string>;
   currentUser: CurrentUser;
   hyperflowConfig: HyperflowConfig;
+  hyperflowJwt: string;
 };
 
 export type HyperflowParams = {
@@ -42,7 +43,8 @@ export type HyperflowParams = {
 };
 
 export type SupportChatProps = {
-  getJwtPromise: () => Promise<string>;
+  accountsJwt: () => Promise<string>;
   currentUser: CurrentUser;
   hyperflowConfig: HyperflowConfig;
+  hyperflowJwt: string;
 };

--- a/_dev/App.tsx
+++ b/_dev/App.tsx
@@ -57,7 +57,8 @@ function App() {
               flowId: 'bla',
               origin: 'blinket'
             }}
-            getJwtPromise={() => Promise.resolve('')}
+            accountsJwt={() => Promise.resolve('')}
+            hyperflowJwt=''
           />
 
           <Topbar.Search onEnter={onSearchEnter} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "1.4.6-beta.2",
+  "version": "1.4.6-beta.3",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
## What?
Mudando as props do componente do Hyperflow para aceitar um JWT criado a partir de um secret na plataforma deles. Os dados nesse JWT vão permitir um log do chat individual para cada conta (mesmo usando controle de acesso).

## Why?
Cada utilizador terá seu log individual, mesmo se ele administrar mais de uma conta.

## How?
Componente é utilizado no myeduzz-front, e o JWT é gerado no myeduzz-api com base no secret da Hyperflow

## Testing?

## Screenshots (optional)

## Anything Else?
