### PR TITLE
feat(sidebar): criacao do componente de grupos de grupos

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Para simplificar a escrita do código, você pode desestruturar os componentes.
 import Layout from '@eduzz/ui-layout';
 
 const { Sidebar, Topbar, Content } = Layout;
-const { Item, Group } = Sidebar;
+const { Item, Group, GroupWithGroupSwitcher } = Sidebar;
 
 function CustomLayout() {
   return (
@@ -68,7 +68,7 @@ export default CustomLayout;
 import { NavLink, useLocation } from 'react-router-dom';
 
 const { Sidebar, Topbar, Content } = Layout;
-const { Item, Group } = Sidebar;
+const { Item, Group, GroupWithGroupSwitcher } = Sidebar;
 
 function MyComponent() {
   const location = useLocation();
@@ -108,6 +108,41 @@ function MyComponent() {
 
       <Sidebar currentLocation={location.pathname}>
         <Item href='/agendamento'>Resumo</Item>
+
+        <GroupWithGroupSwitcher
+            label='Integrações'
+            options={[
+              {
+                id: 'whatsapp',
+                label: 'Whatsapp',
+                icon: <WhatsAppOutlined />,
+                items: [
+                  <Item key={'option-1-item-1'} id='sidebar-option-1-item-1'>
+                    Templates
+                  </Item>,
+                  <Item key={'option-1-item-2'} id='sidebar-option-1-item-2'>
+                    Configurações
+                  </Item>
+                ]
+              },
+              {
+                id: 'email',
+                label: 'Email',
+                icon: <MailOutlined />,
+                items: [
+                  <Item key={'option-2-item-1'} id='sidebar-option-2-item-1'>
+                    Layout
+                  </Item>,
+                  <Item key={'option-2-item-2'} id='sidebar-option-2-item-2'>
+                    Templates
+                  </Item>,
+                  <Item key={'option-2-item-3'} id='sidebar-option-2-item-3'>
+                    Configurações
+                  </Item>
+                ]
+              }
+            ]}
+          />
 
         <Group label='Agendamento'>
           <Item as={NavLink} to='/agendamento'>
@@ -250,6 +285,25 @@ Documentação de apoio: [Hyperflow](https://www.notion.so/eduzz/Doc-Implementa-
 |----------|-------------------|-------------|--------|-----------|
 | label    | `React.ReactNode` | `false`     | -      | -         |
 | tabIndex | `number`          | `false`     | -      |           |
+
+### Sidebar.SidebarGroupWithGroupSwitcher props
+
+| prop      | tipo                                        | obrigatório | padrão | descrição                                                                                             |
+|-----------|---------------------------------------------|-------------|--------|-------------------------------------------------------------------------------------------------------|
+| id        | `string`                                    | `false`     | -      | Identificador único para o elemento raiz (HTML `<li>`).                                             |
+| label     | `ReactNode`                                 | `false`     | -      | Label ou título do grupo, exibido acima das opções do seletor.                                        |
+| options   | `SidebarGroupWithGroupSwitcherOption[]`     | `true`      | -      | Array de opções que serão renderizadas no grupo. Cada opção define um conjunto de itens e atributos.   |
+| className | `string`                                    | `false`     | -      | Classe CSS adicional para customização do componente.                                               |
+
+### SidebarGroupWithGroupSwitcherOption
+
+| prop  | tipo           | obrigatório | padrão | descrição                                                                              |
+|-------|----------------|-------------|--------|----------------------------------------------------------------------------------------|
+| id    | `string`       | `true`      | -      | Identificador único da opção.                                                          |
+| label | `string`       | `true`      | -      | Texto que representa o rótulo da opção. Pode ser um nome ou título descritivo.         |
+| icon  | `ReactNode`    | `false`     | -      | Elemento opcional que pode conter um ícone ou qualquer outro elemento visual.          |
+| items | `ReactNode[]`  | `true`      | -      | Conjunto de itens (children) que serão renderizados quando a opção estiver selecionada. |
+
 
 ### Content props
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Documentação de apoio: [Hyperflow](https://www.notion.so/eduzz/Doc-Implementa-
 | label    | `React.ReactNode` | `false`     | -      | -         |
 | tabIndex | `number`          | `false`     | -      |           |
 
-### Sidebar.SidebarGroupWithGroupSwitcher props
+### Sidebar.GroupWithGroupSwitcher props
 
 | prop      | tipo                                        | obrigatório | padrão | descrição                                                                                             |
 |-----------|---------------------------------------------|-------------|--------|-------------------------------------------------------------------------------------------------------|

--- a/Sidebar/GroupWithGroupSwitcher/context.ts
+++ b/Sidebar/GroupWithGroupSwitcher/context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'use-context-selector';
+
+export interface SidebarGroupWithGroupSwitcherContextType {
+  selectedGroup: string;
+}
+
+const SidebarGroupWithGroupSwitcherContext = createContext<SidebarGroupWithGroupSwitcherContextType>({
+  selectedGroup: ''
+});
+
+export default SidebarGroupWithGroupSwitcherContext;

--- a/Sidebar/GroupWithGroupSwitcher/index.tsx
+++ b/Sidebar/GroupWithGroupSwitcher/index.tsx
@@ -6,7 +6,7 @@ import CollapseEffect from '../../CollapseEffect';
 import useBoolean from '../../hooks/useBoolean';
 import { cn } from '../../utils/cn';
 
-type SidebarGroupWithGroupSwitcherOption = {
+export type SidebarGroupWithGroupSwitcherOption = {
   id: string;
   label: string;
   icon?: ReactNode;

--- a/Sidebar/GroupWithGroupSwitcher/index.tsx
+++ b/Sidebar/GroupWithGroupSwitcher/index.tsx
@@ -77,7 +77,7 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
             <ul className='uizz-layout-m-0 uizz-layout-block uizz-layout-p-0'>
               <li
                 className={cn(
-                  'uizz-layout-group/menu uizz-layout-grid uizz-layout-gap-1 uizz-layout-px-4 uizz-layout-py-2 uizz-layout-text-sm uizz-layout-font-bold'
+                  'uizz-layout-group/menu uizz-layout-grid uizz-layout-gap-1 uizz-layout-px-4 uizz-layout-py-3 uizz-layout-text-sm uizz-layout-font-bold'
                 )}
               >
                 {label}:

--- a/Sidebar/GroupWithGroupSwitcher/index.tsx
+++ b/Sidebar/GroupWithGroupSwitcher/index.tsx
@@ -1,0 +1,145 @@
+import { ReactNode, forwardRef, memo, useState } from 'react';
+
+import { CaretDownFilled } from '@ant-design/icons';
+
+import CollapseEffect from '../../CollapseEffect';
+import useBoolean from '../../hooks/useBoolean';
+import { cn } from '../../utils/cn';
+
+type SidebarGroupWithGroupSwitcherOption = {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  items: ReactNode[];
+};
+
+export interface SidebarGroupWithGroupSwitcherProps {
+  label?: ReactNode;
+  options: SidebarGroupWithGroupSwitcherOption[];
+  id?: string;
+  className?: string;
+}
+
+const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWithGroupSwitcherProps>(
+  ({ id, label, className, options }, ref) => {
+    const [selectedOption, setSelectedOption] = useState<SidebarGroupWithGroupSwitcherOption>(options[0]);
+    const [optionsVisible, setOptionsVisible] = useBoolean(false);
+
+    return (
+      <li id={id} className={cn(className, 'uizz-layout-block uizz-layout-select-none')} ref={ref}>
+        <div>
+          <div
+            className={cn(
+              'uizz-layout-relative uizz-layout-box-border uizz-layout-grid uizz-layout-min-h-[2.2rem] uizz-layout-cursor-pointer uizz-layout-grid-cols-[1.625rem_1fr] uizz-layout-items-center uizz-layout-gap-2 uizz-layout-rounded-br-[50px] uizz-layout-rounded-tr-[50px] uizz-layout-px-4 uizz-layout-py-2 uizz-layout-leading-[1.15] uizz-layout-outline-none uizz-layout-transition-all hover:uizz-layout-bg-content-title/[0.03] active:uizz-layout-bg-content-title/[0.03] dark:hover:uizz-layout-bg-content-title/[0.08] dark:active:uizz-layout-bg-content-title/[0.03]',
+              {
+                '--active uizz-layout-bg-content-title/[0.03] dark:uizz-layout-bg-content-title/[0.08]': optionsVisible
+              }
+            )}
+            onClick={setOptionsVisible}
+          >
+            <div className='uizz-layout-absolute uizz-layout-left-0 uizz-layout-top-[calc(50%_-_1px)] uizz-layout-mt-[-0.5px] uizz-layout-h-px uizz-layout-w-[30px] uizz-layout-bg-content-title/[0.45] uizz-layout-opacity-30 uizz-layout-transition-[left,_background-color]' />
+
+            <div className='uizz-layout-col-[2] uizz-layout-flex uizz-layout-min-w-0 uizz-layout-justify-between uizz-layout-truncate'>
+              <span className='uizz-layout-text-ellipsis uizz-layout-whitespace-nowrap uizz-layout-break-all uizz-layout-text-sm uizz-layout-uppercase uizz-layout-tracking-[0.03em] uizz-layout-text-content-title/[0.65]'>
+                <div className='uizz-layout-flex uizz-layout-gap-1'>
+                  {selectedOption.icon && (
+                    <div
+                      className={cn('uizz-layout-text-xs', {
+                        'uizz-layout-font-bold': optionsVisible
+                      })}
+                    >
+                      {selectedOption.icon}
+                    </div>
+                  )}
+
+                  {selectedOption.label}
+                </div>
+              </span>
+
+              <CaretDownFilled
+                className='uizz-layout-ml-1'
+                style={{
+                  fontSize: '0.8rem'
+                }}
+              />
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              'uizz-layout-z-[105] uizz-layout-ml-2 uizz-layout-box-border uizz-layout-min-h-10 uizz-layout-w-full uizz-layout-items-center uizz-layout-gap-2 uizz-layout-rounded-[0.5rem_0.5rem_0.5rem_0.5rem] uizz-layout-border-2 uizz-layout-bg-surface-default uizz-layout-px-1 uizz-layout-py-2 uizz-layout-leading-[1.15] uizz-layout-shadow-[2px_4px_12px_rgb(var(--eduzz-ui-layout-content-title)_/_0.16)] uizz-layout-outline-none uizz-layout-transition-all',
+              {
+                'uizz-layout-absolute': optionsVisible,
+                'uizz-layout-hidden': !optionsVisible
+              }
+            )}
+          >
+            <ul className='uizz-layout-m-0 uizz-layout-block uizz-layout-p-0'>
+              <li
+                className={cn(
+                  'uizz-layout-group/menu uizz-layout-grid uizz-layout-gap-1 uizz-layout-px-4 uizz-layout-py-2 uizz-layout-text-sm uizz-layout-font-bold'
+                )}
+              >
+                {label}:
+              </li>
+
+              {options.map(option => {
+                const isSelected = selectedOption.id === option.id;
+
+                return (
+                  <li
+                    onClick={() => {
+                      setSelectedOption(option);
+                      setOptionsVisible();
+                    }}
+                    className={cn(
+                      'uizz-layout-group/menu uizz-layout-flex uizz-layout-cursor-pointer uizz-layout-gap-1 uizz-layout-px-4 uizz-layout-py-2 hover:uizz-layout-bg-content-title/[0.03] active:uizz-layout-bg-content-title/[0.03] dark:hover:uizz-layout-bg-content-title/[0.08] dark:active:uizz-layout-bg-content-title/[0.03]',
+                      {
+                        '--active uizz-layout-bg-content-title/[0.03] dark:uizz-layout-bg-content-title/[0.08]':
+                          isSelected
+                      }
+                    )}
+                    key={`group-option-${option.id}`}
+                  >
+                    {option.icon && (
+                      <div
+                        className={cn('uizz-layout-text-xs', {
+                          'uizz-layout-font-bold': isSelected
+                        })}
+                      >
+                        {option.icon}
+                      </div>
+                    )}
+
+                    <div className='uizz-layout-flex uizz-layout-items-center uizz-layout-justify-between'>
+                      <span
+                        className={cn(
+                          'uizz-layout-whitespace-nowrap uizz-layout-break-all uizz-layout-text-sm uizz-layout-uppercase uizz-layout-tracking-[0.03em]',
+                          {
+                            'uizz-layout-font-bold': isSelected
+                          }
+                        )}
+                      >
+                        {option.label}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        </div>
+
+        <ul className='uizz-layout-m-0  uizz-layout-block uizz-layout-p-0'>
+          <CollapseEffect visibled={true}>
+            <div className=' uizz-layout-pb-[0.7rem] [&_li]:uizz-layout-mb-0'>
+              {selectedOption.items.map(item => item)}
+            </div>
+          </CollapseEffect>
+        </ul>
+      </li>
+    );
+  }
+);
+
+export default memo(SidebarGroupWithGroupSwitcher);

--- a/Sidebar/index.tsx
+++ b/Sidebar/index.tsx
@@ -4,6 +4,7 @@ import { useContextSelector } from 'use-context-selector';
 
 import SidebarContext, { SidebarContextType } from './context';
 import Group from './Group';
+import GroupWithGroupSwitcher from './GroupWithGroupSwitcher';
 import Item from './Item';
 import LayoutContext from '../context';
 import Overlay from '../Overlay';
@@ -67,5 +68,6 @@ const Sidebar = ({ currentLocation, children }: SidebarProps) => {
 
 export default nestedComponent(Sidebar, {
   Item,
-  Group
+  Group,
+  GroupWithGroupSwitcher
 });

--- a/Topbar/index.tsx
+++ b/Topbar/index.tsx
@@ -14,10 +14,10 @@ import Search from './Search';
 import UnitySupportChat from './UnitySupportChat';
 import User from './User';
 import UserMenu from './UserMenu';
+import LayoutContext from '../context';
 import UserMenuDivider from './UserMenu/Divider';
 import UserMenuItem from './UserMenu/Item';
 import UserMenuGroup from './UserMenu/ItemGroup';
-import LayoutContext from '../context';
 import IconClose from '../Icons/Close';
 import IconMenu from '../Icons/Menu';
 import { cn } from '../utils/cn';
@@ -27,6 +27,7 @@ import './style.css';
 
 export interface TopbarProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
+  startChildren?: ReactNode;
   disableApps?: boolean;
   logo?: string;
   logoMobile?: string;
@@ -51,6 +52,7 @@ export interface TopbarProps extends HTMLAttributes<HTMLDivElement> {
 const Topbar = memo<TopbarProps>(
   ({
     children,
+    startChildren,
     currentApplication,
     logo,
     logoMobile,
@@ -113,6 +115,8 @@ const Topbar = memo<TopbarProps>(
               {!!user?.tag && (
                 <p className={cn('eduzz-ui-layout-topbar-tag', `eduzz-ui-layout-topbar-tag-${user.tag}`)}>{user.tag}</p>
               )}
+
+              {startChildren && <div className='uizz-layout-mx-[.5rem]'>{startChildren}</div>}
             </div>
 
             <div className='eduzz-ui-layout-topbar-center' ref={registerCenterPortal} />

--- a/Topbar/index.tsx
+++ b/Topbar/index.tsx
@@ -27,7 +27,6 @@ import './style.css';
 
 export interface TopbarProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
-  startChildren?: ReactNode;
   disableApps?: boolean;
   logo?: string;
   logoMobile?: string;
@@ -52,7 +51,6 @@ export interface TopbarProps extends HTMLAttributes<HTMLDivElement> {
 const Topbar = memo<TopbarProps>(
   ({
     children,
-    startChildren,
     currentApplication,
     logo,
     logoMobile,
@@ -115,8 +113,6 @@ const Topbar = memo<TopbarProps>(
               {!!user?.tag && (
                 <p className={cn('eduzz-ui-layout-topbar-tag', `eduzz-ui-layout-topbar-tag-${user.tag}`)}>{user.tag}</p>
               )}
-
-              {startChildren && <div className='uizz-layout-mx-[.5rem]'>{startChildren}</div>}
             </div>
 
             <div className='eduzz-ui-layout-topbar-center' ref={registerCenterPortal} />

--- a/_dev/App.tsx
+++ b/_dev/App.tsx
@@ -1,13 +1,20 @@
 import { useCallback, useEffect } from 'react';
 
-import { MessageOutlined, BellOutlined, NotificationOutlined, ExperimentOutlined } from '@ant-design/icons';
+import {
+  MessageOutlined,
+  BellOutlined,
+  NotificationOutlined,
+  ExperimentOutlined,
+  WhatsAppOutlined,
+  MailOutlined
+} from '@ant-design/icons';
 
 import Layout from '..';
 import { useAppLoader } from '../AppLoader/context';
 import Avatar from '../Avatar';
 
 const { Sidebar, Topbar, Content } = Layout;
-const { Item, Group } = Sidebar;
+const { Item, Group, GroupWithGroupSwitcher } = Sidebar;
 
 function App() {
   const onSearchEnter = useCallback((search: string, clear: () => void) => {
@@ -104,6 +111,41 @@ function App() {
             <Item target='_blank'>Financeiro</Item>
             <Item>Soluções</Item>
           </Group>
+
+          <GroupWithGroupSwitcher
+            label='Integrações'
+            options={[
+              {
+                id: 'whatsapp',
+                label: 'Whatsapp',
+                icon: <WhatsAppOutlined />,
+                items: [
+                  <Item key={'option-1-item-1'} id='sidebar-option-1-item-1'>
+                    Templates
+                  </Item>,
+                  <Item key={'option-1-item-2'} id='sidebar-option-1-item-2'>
+                    Configurações
+                  </Item>
+                ]
+              },
+              {
+                id: 'email',
+                label: 'Email',
+                icon: <MailOutlined />,
+                items: [
+                  <Item key={'option-2-item-1'} id='sidebar-option-2-item-1'>
+                    Layout
+                  </Item>,
+                  <Item key={'option-2-item-2'} id='sidebar-option-2-item-2'>
+                    Templates
+                  </Item>,
+                  <Item key={'option-2-item-3'} id='sidebar-option-2-item-3'>
+                    Configurações
+                  </Item>
+                ]
+              }
+            ]}
+          />
 
           <Group label='Submenu'>
             <Item>Item 1</Item>

--- a/_dev/App.tsx
+++ b/_dev/App.tsx
@@ -35,6 +35,7 @@ function App() {
             avatar: 'https://cdn.testzz.ninja/myeduzz/upload/3c/8e/3c8e5fc487944315a4ccdc3d95e6bda7',
             ssid: '0000aaaa-11bb-22cc-33dd-444444eeeeee'
           }}
+          startChildren={<div>sou filho</div>}
         >
           <Topbar.UnitySupportChat />
           <Topbar.HyperflowSupportChat

--- a/_dev/App.tsx
+++ b/_dev/App.tsx
@@ -42,7 +42,6 @@ function App() {
             avatar: 'https://cdn.testzz.ninja/myeduzz/upload/3c/8e/3c8e5fc487944315a4ccdc3d95e6bda7',
             ssid: '0000aaaa-11bb-22cc-33dd-444444eeeeee'
           }}
-          startChildren={<div>sou filho</div>}
         >
           <Topbar.UnitySupportChat />
           <Topbar.HyperflowSupportChat

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "1.4.11",
+  "version": "1.5.0",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
feat(topbar): adiciona possibilidade de adicionar filhos no comeco da topbar

## What?

Criação de um componente de grupos na sidebar com opção para trocas de grupos **(a ideia é ter um grupo de itens na sidebar com a opcao de trocar o grupo)**.

Este componente renderiza grupos com opção de adicionar icones na label do grupo e um seletor para poder alterar qual o grupo atual.

## Why?

Esse componente será utilizado no Contact Center V2 para que o usuário possa escolher qual a integração ele está gerenciando **(a configuração de integração)** conforme foi feito no exemplo do ui-layout **(_dev/App.tsx)**, para que não seja necessário o usuário alterar a tela a qual ele está para alterar o tipo da integração a qual ele está trabalhando.

## How?

Lots of tsx and tailwind classes

## Testing?

Basta rodar o projeto utilizando "pnpm dev" e verificar o item de testes no menu lateral

## Screenshots (optional)

FECHADO:

![image](https://github.com/user-attachments/assets/f6e59c75-4133-433e-9f49-eae912db0b71)

ABERTO:

![image](https://github.com/user-attachments/assets/4bc4874b-fcbe-42aa-b41a-35ac598f4812)

DARK MODE:

![image](https://github.com/user-attachments/assets/78c59565-d820-4ee9-92ba-39c03e45cf92)

MOBILE:

![localhost_5174_(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/fae4089d-0832-4389-bccc-924753ebe1e9)

## Anything Else?
