### PR TITLE
fix(links): add correct text color

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @danieloprado @ffernandomoraes @JonathasRodrigues
+*       @produtos-internos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @produtos-internos
+*       @eduzz/produtos-internos

--- a/Sidebar/GroupWithGroupSwitcher/index.tsx
+++ b/Sidebar/GroupWithGroupSwitcher/index.tsx
@@ -47,7 +47,7 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                 <div className='uizz:flex uizz:gap-1 uizz:items-center'>
                   {selectedOption?.icon && (
                     <div
-                      className={cn('uizz:text-xs', {
+                      className={cn({
                         'uizz:font-bold': optionsVisible
                       })}
                     >
@@ -106,7 +106,7 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                   >
                     {option.icon && (
                       <div
-                        className={cn('uizz:text-xs', {
+                        className={cn('uizz:text-xs uizz:leading-none', {
                           'uizz:font-bold': isSelected
                         })}
                       >

--- a/Sidebar/Item/index.tsx
+++ b/Sidebar/Item/index.tsx
@@ -50,7 +50,7 @@ const SidebarItem = forwardRef<HTMLElement, SidebarItemProps>(
         tabIndex: tabIndex ?? 1,
         className: cn(
           className,
-          'uizz:group/menu uizz:mr-[5px] uizz:block uizz:w-full uizz:select-none uizz:rounded-br-[50px] uizz:rounded-tr-[50px] uizz:text-inherit uizz:outline-hidden uizz:outline-0 uizz:hover:bg-content-title/[0.03] uizz:dark:hover:bg-content-title/[0.08] uizz:hover:text-inherit uizz:hover:outline-hidden uizz:focus-visible:bg-content-title/[0.03] uizz:dark:focus-visible:bg-content-title/[0.03] uizz:focus-visible:shadow-[0_0_0_2px_#039be5_inset]',
+          'uizz:group/menu uizz:mr-[5px] uizz:block uizz:w-full uizz:select-none uizz:rounded-br-[50px] uizz:rounded-tr-[50px] uizz:text-content-title uizz:outline-hidden uizz:outline-0 uizz:hover:bg-content-title/[0.03] uizz:dark:hover:bg-content-title/[0.08] uizz:hover:text-inherit uizz:hover:outline-hidden uizz:focus-visible:bg-content-title/[0.03] uizz:dark:focus-visible:bg-content-title/[0.03] uizz:focus-visible:shadow-[0_0_0_2px_#039be5_inset]',
           {
             '--active': active,
             '--disabled': disabled

--- a/Topbar/Apps/Dropdown/index.tsx
+++ b/Topbar/Apps/Dropdown/index.tsx
@@ -76,7 +76,7 @@ const AppsDropdown = memo<AppsDropdownProps>(({ currentApplication, applications
           return (
             <a
               className={cn(
-                'uizz:box-border uizz:block uizz:w-full uizz:cursor-pointer uizz:grid-cols-[2rem_1fr] uizz:grid-rows-[1.5rem_auto] uizz:gap-1 uizz:rounded uizz:border-gray-200 uizz:px-2 uizz:py-4 uizz:text-inherit uizz:no-underline uizz:visited:text-inherit uizz:hover:bg-content-title/[0.03] uizz:hover:text-inherit uizz:group-[.--expanded]/apps:grid uizz:group-[.--expanded]/apps:border-b uizz:group-[.--expanded]/apps:p-4 uizz:dark:border-neutral-800 uizz:dark:hover:bg-content-title/[0.06] uizz:sm:grid-cols-[4rem_1fr] uizz:sm:group-[.--expanded]/apps:border',
+                'uizz:box-border uizz:block uizz:w-full uizz:cursor-pointer uizz:grid-cols-[2rem_1fr] uizz:grid-rows-[1.5rem_auto] uizz:gap-1 uizz:rounded uizz:border-gray-200 uizz:px-2 uizz:py-4 uizz:no-underline uizz:visited:text-inherit uizz:hover:bg-content-title/[0.03] uizz:hover:text-inherit uizz:group-[.--expanded]/apps:grid uizz:group-[.--expanded]/apps:border-b uizz:group-[.--expanded]/apps:p-4 uizz:dark:border-neutral-800 uizz:text-content-caption uizz:dark:hover:bg-content-title/[0.06] uizz:sm:grid-cols-[4rem_1fr] uizz:sm:group-[.--expanded]/apps:border',
                 isCurrent && 'uizz:bg-content-title/[0.03] uizz:dark:bg-content-title/[0.06]'
               )}
               key={app.application}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
This pull request includes several changes related to updating class names and ownership details. The most important changes include updates to the `CODEOWNERS` file, modifications to class names in various components, and a version bump in `package.json`.

Ownership update:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Changed ownership from individual users to the `@eduzz/produtos-internos` team.

Class name updates:

* [`Sidebar/GroupWithGroupSwitcher/index.tsx`](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L50-R50): Updated class names to remove unnecessary text size and add leading-none for better styling. [[1]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L50-R50) [[2]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L109-R109)
* [`Sidebar/Item/index.tsx`](diffhunk://#diff-b6fd7a015520a77036c3507118f1d0fb9ca86eec57eee65a61a7b0ade793184dL53-R53): Modified class names to change text color to `uizz:text-content-title`.
* [`Topbar/Apps/Dropdown/index.tsx`](diffhunk://#diff-8680330d67f23164db5fa7b92a15ad20a2c5c67f10fe8ef8cac628ae86a74e69L79-R79): Updated class names to include `uizz:text-content-caption` and remove redundant text-inherit.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped version from `2.0.0` to `2.0.1`.