### PR TITLE
fix(group-switcher): add truncate

### DIFF
--- a/CollapseEffect/index.tsx
+++ b/CollapseEffect/index.tsx
@@ -10,7 +10,7 @@ export interface CollapseProps {
 
 const CollapseEffect = ({ children, visibled, id }: CollapseProps) => {
   return (
-    <div id={id} className={cn('uizz:h-0 uizz:overflow-hidden', { 'uizz:h-auto!': visibled })}>
+    <div id={id} className={cn('uizz:h-0 uizz:overflow-hidden uizz:truncate w-full', { 'uizz:h-auto!': visibled })}>
       {children}
     </div>
   );

--- a/Sidebar/GroupWithGroupSwitcher/index.tsx
+++ b/Sidebar/GroupWithGroupSwitcher/index.tsx
@@ -42,8 +42,8 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
           >
             <div className='uizz:absolute uizz:left-0 uizz:top-[calc(50%-1px)] uizz:mt-[-0.5px] uizz:h-px uizz:w-[30px] uizz:bg-content-title/[0.45] uizz:opacity-30 uizz:transition-[left,background-color]' />
 
-            <div className='uizz:col-2 uizz:flex uizz:min-w-0 uizz:justify-between uizz:truncate'>
-              <span className='uizz:text-ellipsis uizz:whitespace-nowrap uizz:break-all uizz:text-sm uizz:uppercase uizz:tracking-[0.03em] uizz:text-content-title/[0.65]'>
+            <div className='uizz:col-2 uizz:w-full uizz:flex uizz:min-w-0 uizz:justify-between'>
+              <span className='uizz:overflow-hidden uizz:text-sm uizz:uppercase uizz:tracking-[0.03em] uizz:text-content-title/[0.65] flex-1'>
                 <div className='uizz:flex uizz:gap-1 uizz:items-center'>
                   {selectedOption?.icon && (
                     <div
@@ -54,13 +54,14 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                       {selectedOption.icon}
                     </div>
                   )}
-
-                  {selectedOption?.label}
+                  <div className='uizz:truncate' title={selectedOption?.label}>
+                    {selectedOption?.label}
+                  </div>
                 </div>
               </span>
 
               <CaretDownFilled
-                className='uizz:ml-1'
+                className='uizz:ml-1 uizz:w-fit uizz:shrink-0'
                 style={{
                   fontSize: '0.8rem'
                 }}
@@ -97,7 +98,7 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                       setOptionsVisible();
                     }}
                     className={cn(
-                      'uizz:group uizz:flex uizz:cursor-pointer uizz:gap-1 uizz:px-4 uizz:py-2 uizz:items-center uizz:hover:bg-content-title/[0.03] uizz:active:bg-content-title/[0.03] uizz:dark:hover:bg-content-title/[0.08] uizz:dark:active:bg-content-title/[0.03]',
+                      'uizz:group uizz:flex uizz:cursor-pointer uizz:gap-1 uizz:px-4 uizz:py-2 uizz:items-center uizz:hover:bg-content-title/[0.03] uizz:active:bg-content-title/[0.03] uizz:dark:hover:bg-content-title/[0.08] uizz:dark:active:bg-content-title/[0.03] uizz:w-full',
                       {
                         '--active uizz:bg-content-title/[0.03] uizz:dark:bg-content-title/[0.08]': isSelected
                       }
@@ -106,7 +107,7 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                   >
                     {option.icon && (
                       <div
-                        className={cn('uizz:text-xs uizz:leading-none', {
+                        className={cn('uizz:text-xs uizz:shrink-0 uizz:leading-none', {
                           'uizz:font-bold': isSelected
                         })}
                       >
@@ -114,10 +115,13 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
                       </div>
                     )}
 
-                    <div className='uizz:flex uizz:items-center uizz:justify-between'>
+                    <div
+                      title={option.label}
+                      className='uizz:flex uizz:flex-1 uizz:items-center uizz:justify-between uizz:overflow-hidden'
+                    >
                       <span
                         className={cn(
-                          'uizz:whitespace-nowrap uizz:break-all uizz:text-sm uizz:uppercase uizz:tracking-[0.03em]',
+                          'uizz:whitespace-nowrap uizz:break-all uizz:text-sm uizz:uppercase uizz:tracking-[0.03em] uizz:truncate',
                           {
                             'uizz:font-bold': isSelected
                           }
@@ -135,7 +139,9 @@ const SidebarGroupWithGroupSwitcher = forwardRef<HTMLLIElement, SidebarGroupWith
 
         <ul className='uizz:m-0 uizz:block uizz:p-0'>
           <CollapseEffect visibled={true}>
-            <div className='uizz:pb-[0.7rem] uizz:[&_li]:mb-0'>{(selectedOption?.items || []).map(item => item)}</div>
+            <div className='uizz:pb-[0.7rem] uizz:[&_li]:mb-0 uizz:w-full'>
+              {(selectedOption?.items || []).map(item => item)}
+            </div>
           </CollapseEffect>
         </ul>
       </li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eduzz/ui-layout",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "keywords": [
     "eduzz",
     "react",


### PR DESCRIPTION
This pull request focuses on improving the layout and responsiveness of UI components, particularly within the `SidebarGroupWithGroupSwitcher` and `CollapseEffect` components. Additionally, it includes a version bump in `package.json`. The most important changes are grouped below:

![Screenshot 2025-04-23 at 08 58 57](https://github.com/user-attachments/assets/c14700b5-7cb3-418e-aeb6-416173ae454d)

### Layout and Responsiveness Improvements:

* **`CollapseEffect/index.tsx`:** Enhanced the `CollapseEffect` component's container by adding `uizz:truncate` and `w-full` classes, ensuring better handling of overflowing content and full-width styling.

* **`Sidebar/GroupWithGroupSwitcher/index.tsx`:**
  - Improved content alignment and truncation by adding `uizz:w-full` and `uizz:truncate` classes to the main container and child elements. [[1]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L45-R46) [[2]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L57-R64)
  - Updated the dropdown options to include truncation (`uizz:truncate`) and tooltips (`title` attribute) for better usability when labels are long. [[1]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L57-R64) [[2]](diffhunk://#diff-fa96d681ab0c1ede2bc579c512e07d9df22878751beef5a5b0a6df3c14322e66L109-R124)
  - Ensured full-width responsiveness for clickable elements by adding `uizz:w-full` to the dropdown option container.
  - Adjusted the layout of nested items in the `CollapseEffect` component to ensure proper width handling using `uizz:w-full`.

### Version Update:

* **`package.json`:** Incremented the package version from `2.0.3` to `2.0.4` to reflect the changes made in the codebase.
